### PR TITLE
fix the false apple

### DIFF
--- a/apple.py
+++ b/apple.py
@@ -62,6 +62,8 @@ class apple(commands.Cog):
         """------ tells you how many apples you have"""
         db = pickledb.load('appledb', False)
         apple_count = db.get(str(ctx.author.id))
+        if apple_count == False or apple_count == str(False):
+            await ctx.send("you don't have any apples :(")
         await ctx.send("you've got {count} apples!".format(count=str(apple_count)))
         db.dump()
 

--- a/apple.py
+++ b/apple.py
@@ -62,9 +62,10 @@ class apple(commands.Cog):
         """------ tells you how many apples you have"""
         db = pickledb.load('appledb', False)
         apple_count = db.get(str(ctx.author.id))
-        if apple_count == False or apple_count == str(False):
+        if apple_count == False:
             await ctx.send("you don't have any apples :(")
-        await ctx.send("you've got {count} apples!".format(count=str(apple_count)))
+        else:
+            await ctx.send("you've got {count} apples!".format(count=str(apple_count)))
         db.dump()
 
     @commands.command()


### PR DESCRIPTION
stop `apl count` displaying to the user as "False" if the user has 0 apples, and added a string that will be presented instead

![BFC4F7CB4e5FB481 1](https://user-images.githubusercontent.com/41978021/104794592-9e635700-5776-11eb-9c2c-b722654a50ed.png)
